### PR TITLE
Ensure trailing slash in S3_PREFIX variable

### DIFF
--- a/mongodb/s3.sh
+++ b/mongodb/s3.sh
@@ -5,4 +5,4 @@ FILENAME=mongobackup.tar.gz
 
 tar czf ./mongoBackups/${FILENAME} ./mongoBackups/db/*
 
-test -f ./mongoBackups/${FILENAME} && aws s3api put-object --bucket $BUCKET_NAME --key "${S3_PREFIX:+${S3_PREFIX}/}mongo-backup/$FILENAME" --body ./mongoBackups/${FILENAME}
+test -f ./mongoBackups/${FILENAME} && aws s3api put-object --bucket $BUCKET_NAME --key "${S3_PREFIX}mongo-backup/$FILENAME" --body ./mongoBackups/${FILENAME}

--- a/mysql/backup.sh
+++ b/mysql/backup.sh
@@ -9,7 +9,7 @@ echo "$FILE_PATH""$FILE"
 TAR_MD5_SUM=$(openssl md5 -binary "$FILE_PATH$FILE".tar.gz | base64)                                                                                                    
 SQL_MD5_SUM=$(openssl md5 -binary $FILE_PATH$FILE".sql" | base64)                                                                                                       
 #REMOTE_SQL_MD5_SUM=$(aws s3api head-object --bucket $BUCKET --key "$FILE".tar.gz --query 'Metadata.sqlmd5checksum' --output text)
-REMOTE_SQL_MD5_SUM=$(aws s3api head-object --bucket $BUCKET --key "${S3_PREFIX:+${S3_PREFIX}/}$FILE".tar.gz --query 'Metadata.sqlmd5checksum' --output text 2>&1) || (if grep -q "An error occurred (404) when calling the HeadObject operation: Not Found" <<< "$REMOTE_SQL_MD5_SUM"; then echo "$REMOTE_SQL_MD5_SUM"; else echo "$REMOTE_SQL_MD5_SUM" 1>&2; fi)
+REMOTE_SQL_MD5_SUM=$(aws s3api head-object --bucket $BUCKET --key "${S3_PREFIX}$FILE".tar.gz --query 'Metadata.sqlmd5checksum' --output text 2>&1) || (if grep -q "An error occurred (404) when calling the HeadObject operation: Not Found" <<< "$REMOTE_SQL_MD5_SUM"; then echo "$REMOTE_SQL_MD5_SUM"; else echo "$REMOTE_SQL_MD5_SUM" 1>&2; fi)
 
 echo $SQL_MD5_SUM                                                                                                                                                       
 echo $REMOTE_SQL_MD5_SUM                                                                                                                                                

--- a/mysql/restore.sh
+++ b/mysql/restore.sh
@@ -20,7 +20,7 @@ BACKUP_FILE="restore-$TIME_STAMP"
 
 echo "Getting last backup..."
 if [[ -z "$VERSION_ID" || "$VERSION_ID" == 'latest' ]]; then VERSION_OPTION=''; else VERSION_OPTION="--version-id $VERSION_ID"; fi
-aws s3api get-object --bucket $BUCKET_NAME --key "${S3_PREFIX:+${S3_PREFIX}/}$FILENAME".tar.gz $BACKUP_FILE.tar.gz $VERSION_OPTION $AWS_ARGS
+aws s3api get-object --bucket $BUCKET_NAME --key "${S3_PREFIX}$FILENAME".tar.gz $BACKUP_FILE.tar.gz $VERSION_OPTION $AWS_ARGS
 
 echo "Extracting last backup..."
 mkdir -p "$FILE_PATH"restores

--- a/script.sh
+++ b/script.sh
@@ -13,6 +13,8 @@ fi
 
 if [ -z ${S3_PREFIX} ] ; then
   echo "S3_PREFIX is not set, backups will be stored in the root of the bucket."
+elif [[ -n "$S3_PREFIX" && "${S3_PREFIX: -1}" != "/" ]]; then
+  S3_PREFIX="${S3_PREFIX}/"
 else
   echo "S3_PREFIX is set to ${S3_PREFIX}";
 fi


### PR DESCRIPTION
#### Description

Add trailing slash in prefix variable fetched from environment only if it doesn't have one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of S3 backup paths to ensure consistent use of slashes in the S3 prefix, preventing path errors during backup and restore operations.
- **Chores**
	- Adjusted scripts to automatically append a trailing slash to the S3 prefix if missing, ensuring correct path construction for S3 object storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->