### PR TITLE
Update Dockerfile to use alpine 3.23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.23.3
 LABEL maintainer="mohit@getfundwave.com"
 
-RUN apk update && apk add --no-cache \
+RUN apk add --no-cache \
     python3 \
     py3-pip \
     mongodb-tools \
@@ -13,8 +13,6 @@ RUN apk update && apk add --no-cache \
     && pip3 install --upgrade pip --break-system-packages \
     && pip3 install awscli --break-system-packages \
     && mkdir -p /opt/backup
-
-ARG HOUR_OF_DAY
 
 WORKDIR /opt/backup
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,29 @@
-FROM alpine:3.18.3
+FROM alpine:3.23.3
 LABEL maintainer="mohit@getfundwave.com"
 
-RUN apk update && apk add --no-cache python3 py3-pip \
-    && pip3 install --upgrade pip \
-    && apk add mongodb-tools \
-    && pip3 install awscli \
-    && apk add mysql-client bash openssl coreutils curl \
+RUN apk update && apk add --no-cache \
+    python3 \
+    py3-pip \
+    mongodb-tools \
+    mysql-client \
+    bash \
+    openssl \
+    coreutils \
+    curl \
+    && pip3 install --upgrade pip --break-system-packages \
+    && pip3 install awscli --break-system-packages \
     && mkdir -p /opt/backup
+
 ARG HOUR_OF_DAY
-#ENV CRON_HOUR=${HOUR_OF_DAY:-23}
 
 WORKDIR /opt/backup
-COPY crontab.txt crontab.txt
-COPY entry.sh entry.sh
-COPY script.sh script.sh
 
-COPY mysql/mysql-backup.sh mysql/mysql-backup.sh
-COPY mysql/backup.sh mysql/backup.sh
-COPY mysql/clean.sh mysql/clean.sh
+COPY crontab.txt entry.sh script.sh ./
+COPY mysql/ ./mysql/
+COPY mongodb/ ./mongodb/
 
-COPY mongodb/mongo-backup.sh mongodb/mongo-backup.sh
-COPY mongodb/s3.sh mongodb/s3.sh
-COPY mongodb/clean.sh mongodb/clean.sh
-
-RUN chmod 750 entry.sh script.sh
-RUN chmod 750 mysql/mysql-backup.sh mysql/backup.sh mysql/clean.sh
-RUN chmod 750 mongodb/mongo-backup.sh mongodb/s3.sh mongodb/clean.sh
-
-#RUN if [[ -n "$HOUR_OF_DAY" ]] ; then echo $HOUR_OF_DAY && sed -i "s/23/$HOUR_OF_DAY/g" crontab.txt && cat crontab.txt ; else echo "Defaulting to cron hour 23" ; fi
-#RUN /usr/bin/crontab crontab.txt
+RUN chmod 750 entry.sh script.sh \
+    && chmod 750 mysql/*.sh \
+    && chmod 750 mongodb/*.sh
 
 CMD ["/opt/backup/entry.sh"]


### PR DESCRIPTION
#### Description

Upgrade alpine to latest available 3.23.3 as previous one has vulnerable packages.

No breaking changes

#### Resolutions

- fixes 

#### Depends on

NA

#### Deployment

Current pipelines will suffice


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated base container image to Alpine Linux 3.23.3 for improved security and stability.
  * Simplified Docker build configuration for more efficient deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->