### PR TITLE
feat: Add support for tagging backup objects

### DIFF
--- a/mongodb/s3.sh
+++ b/mongodb/s3.sh
@@ -5,4 +5,9 @@ FILENAME=mongobackup.tar.gz
 
 tar czf ./mongoBackups/${FILENAME} ./mongoBackups/db/*
 
-test -f ./mongoBackups/${FILENAME} && aws s3api put-object --bucket $BUCKET_NAME --key "${S3_PREFIX}mongo-backup/$FILENAME" --body ./mongoBackups/${FILENAME} --tagging 'BACKUP_TYPE=MONGODB'
+TAGGING_PARAM=""
+if [[ "${ENABLE_S3_TAGS}" == "true" ]]; then
+  TAGGING_PARAM="--tagging BACKUP_TYPE=MONGODB"
+fi
+
+test -f ./mongoBackups/${FILENAME} && aws s3api put-object --bucket $BUCKET_NAME --key "${S3_PREFIX}mongo-backup/$FILENAME" --body ./mongoBackups/${FILENAME} $TAGGING_PARAM

--- a/mongodb/s3.sh
+++ b/mongodb/s3.sh
@@ -5,4 +5,4 @@ FILENAME=mongobackup.tar.gz
 
 tar czf ./mongoBackups/${FILENAME} ./mongoBackups/db/*
 
-test -f ./mongoBackups/${FILENAME} && aws s3api put-object --bucket $BUCKET_NAME --key "${S3_PREFIX:+${S3_PREFIX}/}mongo-backup/$FILENAME" --body ./mongoBackups/${FILENAME}
+test -f ./mongoBackups/${FILENAME} && aws s3api put-object --bucket $BUCKET_NAME --key "${S3_PREFIX:+${S3_PREFIX}/}mongo-backup/$FILENAME" --body ./mongoBackups/${FILENAME} --tagging 'BACKUP_TYPE=MONGODB'

--- a/mysql/backup.sh
+++ b/mysql/backup.sh
@@ -22,6 +22,11 @@ fi
 
 echo "Changes found since last upload. Uploading now."
 
-aws s3api put-object --bucket $BUCKET --key "${S3_PREFIX%/}/$FILE".tar.gz --body "$FILE_PATH$FILE".tar.gz --content-md5 $TAR_MD5_SUM --metadata sqlmd5checksum=$SQL_MD5_SUM --tagging 'BACKUP_TYPE=MYSQL'
+TAGGING_PARAM=""
+if [[ "${ENABLE_S3_TAGS}" == "true" ]]; then
+  TAGGING_PARAM="--tagging BACKUP_TYPE=MYSQL"
+fi
+
+aws s3api put-object --bucket $BUCKET --key "${S3_PREFIX%/}/$FILE".tar.gz --body "$FILE_PATH$FILE".tar.gz --content-md5 $TAR_MD5_SUM --metadata sqlmd5checksum=$SQL_MD5_SUM $TAGGING_PARAM
 
 echo "Backup complete"

--- a/mysql/backup.sh
+++ b/mysql/backup.sh
@@ -22,6 +22,4 @@ fi
                                                                                                                                                                         
 echo "Changes found since last upload. Uploading now."                                                                                                                  
                                                                                                                                                                         
-aws s3api put-object --bucket $BUCKET --key "${S3_PREFIX:+${S3_PREFIX}/}$FILE".tar.gz --body "$FILE_PATH$FILE".tar.gz --content-md5 $TAR_MD5_SUM --metadata sqlmd5checksum=$SQL_MD5_SUM             
-                                                                                                                                                                        
-echo "Backup complete"                                                                                                                                                  
+aws s3api put-object --bucket $BUCKET --key "${S3_PREFIX:+${S3_PREFIX}/}$FILE".tar.gz --body "$FILE_PATH$FILE".tar.gz --content-md5 $TAR_MD5_SUM --metadata sqlmd5checksum=$SQL_MD5_SUM --tagging 'BACKUP_TYPE=MYSQL'


### PR DESCRIPTION
#### Description

This PR allows you to conditionally tag backup objects with a BACKUP_TYPE tag with values MYSQL and MONGODB.

Example use-case: You want to create a lifecycle policy on your S3 bucket that applies to objects with specific tags.

Files changed - 

- mongodb/s3.sh
- mysql/backup.sh

#### Deployment

Current pipelines will suffice


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added conditional S3 object tagging capability for MongoDB and MySQL backup uploads. When the S3 tagging option is enabled, MongoDB backups receive custom metadata tags and MySQL backups are tagged with their backup type. This feature is disabled by default and can be toggled via configuration settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fundwave/s3-db-backup-cron/pull/9)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->